### PR TITLE
Add user_address as an example of belongs_to feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,14 @@ source 'http://rubygems.org'
 gem 'rails', '3.0.10'
 gem 'sqlite3-ruby', :require => 'sqlite3'
 gem 'nifty-generators'
-gem "activeadmin", '0.4.0'
+gem "activeadmin", :git => "git://github.com/gregbell/active_admin.git"
 gem "faker"
 gem 'newrelic_rpm', '3.1.1'
 gem 'hoptoad_notifier', '2.4.11'
 
+gem 'country-select'
+
 group :development do
   gem 'mechanize'
 end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,19 @@
+GIT
+  remote: git://github.com/gregbell/active_admin.git
+  revision: 82a13de45feeba2510f015aaae9d412878e4c6f5
+  specs:
+    activeadmin (0.4.2)
+      bourbon (>= 1.0.0)
+      devise (>= 1.1.2)
+      fastercsv
+      formtastic (>= 2.0.0)
+      inherited_resources (> 0)
+      jquery-rails (>= 1.0.0)
+      kaminari (>= 0.13.0)
+      meta_search (>= 0.9.2)
+      rails (>= 3.0.0)
+      sass (>= 3.1.0)
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -15,17 +31,6 @@ GEM
       rack-mount (~> 0.6.14)
       rack-test (~> 0.5.7)
       tzinfo (~> 0.3.23)
-    activeadmin (0.4.0)
-      bourbon (>= 1.0.0)
-      devise (>= 1.1.2)
-      fastercsv
-      formtastic (>= 2.0.0)
-      inherited_resources (< 1.3.0)
-      jquery-rails (>= 1.0.0)
-      kaminari (>= 0.13.0)
-      meta_search (>= 0.9.2)
-      rails (>= 3.0.0)
-      sass (>= 3.1.0)
     activemodel (3.0.10)
       activesupport (= 3.0.10)
       builder (~> 2.1.2)
@@ -39,11 +44,14 @@ GEM
       activemodel (= 3.0.10)
       activesupport (= 3.0.10)
     activesupport (3.0.10)
+    archive-tar-minitar (0.5.2)
     arel (2.0.10)
     bcrypt-ruby (3.0.1)
-    bourbon (1.3.6)
+    bourbon (1.4.0)
       sass (>= 3.1)
     builder (2.1.2)
+    columnize (0.3.6)
+    country-select (1.1.0)
     devise (1.5.3)
       bcrypt-ruby (~> 3.0)
       orm_adapter (~> 0.0.3)
@@ -60,7 +68,7 @@ GEM
       activesupport
       builder
     i18n (0.5.0)
-    inherited_resources (1.2.2)
+    inherited_resources (1.3.0)
       has_scope (~> 0.5.0)
       responders (~> 0.6.0)
     jquery-rails (1.0.19)
@@ -70,6 +78,8 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
+    linecache19 (0.5.12)
+      ruby_core_source (>= 0.1.4)
     mail (2.2.19)
       activesupport (>= 2.3.6)
       i18n (>= 0.4.0)
@@ -115,7 +125,17 @@ GEM
     rake (0.9.2)
     rdoc (3.9.4)
     responders (0.6.5)
-    sass (3.1.12)
+    ruby-debug-base19 (0.11.25)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby_core_source (>= 0.1.4)
+    ruby-debug19 (0.11.6)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby-debug-base19 (>= 0.11.19)
+    ruby_core_source (0.1.5)
+      archive-tar-minitar (>= 0.5.2)
+    sass (3.1.15)
     sqlite3 (1.3.4)
     sqlite3-ruby (1.3.3)
       sqlite3 (>= 1.3.3)
@@ -124,7 +144,7 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.29)
-    warden (1.1.0)
+    warden (1.1.1)
       rack (>= 1.0)
     webrobots (0.0.11)
       nokogiri (>= 1.4.4)
@@ -133,11 +153,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activeadmin (= 0.4.0)
+  activeadmin!
+  country-select
   faker
   hoptoad_notifier (= 2.4.11)
   mechanize
   newrelic_rpm (= 3.1.1)
   nifty-generators
   rails (= 3.0.10)
+  ruby-debug19
   sqlite3-ruby

--- a/app/admin/dashboards.rb
+++ b/app/admin/dashboards.rb
@@ -2,15 +2,15 @@ ActiveAdmin::Dashboards.build do
 
   section "Recent Orders", :priority => 1 do
     table_for Order.complete.order('id desc').limit(10) do
-      column("State")   {|order| status_tag(order.state)                                    } 
-      column("Customer"){|order| link_to(order.user.email, admin_customer_path(order.user)) } 
-      column("Total")   {|order| number_to_currency order.total_price                       } 
+      column("State")   {|order| status_tag(order.state)                                    }
+      column("Customer"){|order| link_to(order.user.email, admin_user_path(order.user)) }
+      column("Total")   {|order| number_to_currency order.total_price                       }
     end
   end
 
   section "Recent Customers", :priority => 2 do
-    table_for User.order('id desc').limit(10).each do |customer|
-      column(:email)    {|customer| link_to(customer.email, admin_customer_path(customer)) }
+    table_for User.order('id desc').limit(10).each do |user|
+      column(:email)    {|user| link_to(user.email, admin_user_path(user)) }
     end
   end
 
@@ -29,7 +29,7 @@ ActiveAdmin::Dashboards.build do
   # Define your dashboard sections here. Each block will be
   # rendered on the dashboard in the context of the view. So just
   # return the content which you would like to display.
-  
+
   # == Simple Dashboard Section
   # Here is an example of a simple dashboard section
   #
@@ -40,7 +40,7 @@ ActiveAdmin::Dashboards.build do
   #       end.join.html_safe
   #     end
   #   end
-  
+
   # == Render Partial Section
   # The block is rendererd within the context of the view, so you can
   # easily render a partial rather than build content in ruby.
@@ -48,7 +48,7 @@ ActiveAdmin::Dashboards.build do
   #   section "Recent Posts" do
   #     render 'recent_posts' # => this will render /app/views/admin/dashboard/_recent_posts.html.erb
   #   end
-  
+
   # == Section Ordering
   # The dashboard sections are ordered by a given priority from top left to
   # bottom right. The default priority is 10. By giving a section numerically lower
@@ -60,3 +60,4 @@ ActiveAdmin::Dashboards.build do
   # Will render the "Recent Users" then the "Recent Posts" sections on the dashboard.
 
 end
+

--- a/app/admin/user_addresses.rb
+++ b/app/admin/user_addresses.rb
@@ -1,4 +1,18 @@
 ActiveAdmin.register UserAddress do
+  belongs_to  :user
 
+  form do |f|
+    f.inputs do
+      f.input :user_id,     :as => :hidden, :value => params[:user_id]
+      f.input :fullname
+      f.input :address_line1
+      f.input :address_line2
+      f.input :city
+      f.input :state
+      f.input :zipcode
+      f.input :country
+    end
+    f.buttons :commit
+  end
 end
 

--- a/app/admin/user_addresses.rb
+++ b/app/admin/user_addresses.rb
@@ -1,0 +1,4 @@
+ActiveAdmin.register UserAddress do
+
+end
+

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,4 +1,4 @@
-ActiveAdmin.register User, :as => "Customer" do
+ActiveAdmin.register User do
 
   filter :username
   filter :email
@@ -14,24 +14,41 @@ ActiveAdmin.register User, :as => "Customer" do
 
   show :title => :username do
     panel "Order History" do
-      table_for(customer.orders) do
+      table_for(user.orders) do
         column("Order", :sortable => :id) {|order| link_to "##{order.id}", admin_order_path(order) }
         column("State")                   {|order| status_tag(order.state) }
         column("Date", :sortable => :checked_out_at){|order| pretty_format(order.checked_out_at) }
         column("Total")                   {|order| number_to_currency order.total_price }
       end
     end
+
+    panel "Address Book" do
+      table_for(user.user_addresses) do
+        column("Fullname") {|a| link_to "#{a.fullname}", admin_user_user_address_path(user.id, a.id) }
+        column("Address") {|a|
+          span "#{a.address_line1}"
+          br "#{a.address_line2}"
+        }
+        column :city
+        column :state
+        column :country
+        column :zipcode
+        tr :class => "action_items" do
+          td link_to("New Address", new_admin_user_user_address_path(user), :class => :button)
+        end
+      end
+    end
     active_admin_comments
   end
 
   sidebar "Customer Details", :only => :show do
-    attributes_table_for customer, :username, :email, :created_at
+    attributes_table_for user, :username, :email, :created_at
   end
 
   sidebar "Order History", :only => :show do
-    attributes_table_for customer do
-      row("Total Orders") { customer.orders.complete.count }
-      row("Total Value") { number_to_currency customer.orders.complete.sum(:total_price) }
+    attributes_table_for user do
+      row("Total Orders") { user.orders.complete.count }
+      row("Total Value") { number_to_currency user.orders.complete.sum(:total_price) }
     end
   end
 
@@ -39,3 +56,4 @@ ActiveAdmin.register User, :as => "Customer" do
     render('/admin/sidebar_links', :model => 'users')
   end
 end
+

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ActiveRecord::Base
 
   has_many :orders, :dependent => :destroy
 
+  has_many :user_addresses
+
   # new columns need to be added here to be writable through mass assignment
   attr_accessible :username, :email, :password, :password_confirmation
 
@@ -39,3 +41,4 @@ class User < ActiveRecord::Base
     Digest::SHA1.hexdigest([pass, password_salt].join)
   end
 end
+

--- a/app/models/user_address.rb
+++ b/app/models/user_address.rb
@@ -1,0 +1,2 @@
+class UserAddress < ActiveRecord::Base
+end

--- a/app/models/user_address.rb
+++ b/app/models/user_address.rb
@@ -1,2 +1,14 @@
 class UserAddress < ActiveRecord::Base
+  belongs_to :user
+
+  validates_presence_of :user_id
+  validates_associated  :user
+
+  validates_presence_of :fullname
+  validates_presence_of :address_line1
+  validates_presence_of :city
+  validates_presence_of :state
+  validates_presence_of :zipcode
+  validates_presence_of :country
 end
+

--- a/db/migrate/20120222083938_create_user_addresses.rb
+++ b/db/migrate/20120222083938_create_user_addresses.rb
@@ -1,0 +1,21 @@
+class CreateUserAddresses < ActiveRecord::Migration
+  def self.up
+    create_table :user_addresses do |t|
+      t.integer  :user_id
+      t.string   :fullname
+      t.string   :address_line1
+      t.string   :address_line2
+      t.string   :city
+      t.string   :state
+      t.string   :zipcode
+      t.string   :country
+      t.timestamps
+    end
+    add_index(:user_addresses, :user_id)
+  end
+
+  def self.down
+    drop_table :user_addresses
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110426072324) do
+ActiveRecord::Schema.define(:version => 20120222083938) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.integer  "resource_id",   :null => false
@@ -80,6 +81,21 @@ ActiveRecord::Schema.define(:version => 20110426072324) do
 
   add_index "products", ["available_on"], :name => "index_products_on_available_on"
   add_index "products", ["featured"], :name => "index_products_on_featured"
+
+  create_table "user_addresses", :force => true do |t|
+    t.integer  "user_id"
+    t.string   "fullname"
+    t.string   "address_line1"
+    t.string   "address_line2"
+    t.string   "city"
+    t.string   "state"
+    t.string   "zipcode"
+    t.string   "country"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "user_addresses", ["user_id"], :name => "index_user_addresses_on_user_id"
 
   create_table "users", :force => true do |t|
     t.string   "username"

--- a/public/stylesheets/active_admin.css
+++ b/public/stylesheets/active_admin.css
@@ -1451,7 +1451,7 @@ a:hover {
   -moz-box-shadow: inset 0 1px 4px #dddddd;
   -webkit-box-shadow: inset 0 1px 4px #dddddd;
   margin-bottom: 20px; }
-  .section h3, .panel h3 {
+  .section > h3, .panel > h3 {
     background: #efefef;
     background: -webkit-gradient(linear, left top, left bottom, from(#efefef), to(#dfe1e2));
     background: -moz-linear-gradient(-90deg, #efefef, #dfe1e2);
@@ -1475,12 +1475,12 @@ a:hover {
     margin-bottom: 0.5em;
     color: #5e6469;
     padding: 5px 10px 3px 10px; }
-    .section h3 span.icon svg path, .section h3 span.icon svg polygon, .section h3 span.icon svg rect, .section h3 span.icon svg circle, .panel h3 span.icon svg path, .panel h3 span.icon svg polygon, .panel h3 span.icon svg rect, .panel h3 span.icon svg circle {
+    .section > h3 span.icon svg path, .section > h3 span.icon svg polygon, .section > h3 span.icon svg rect, .section > h3 span.icon svg circle, .panel > h3 span.icon svg path, .panel > h3 span.icon svg polygon, .panel > h3 span.icon svg rect, .panel > h3 span.icon svg circle {
       fill: #5e6469 !important; }
-    .section h3 span.icon, .panel h3 span.icon {
+    .section > h3 span.icon, .panel > h3 span.icon {
       width: 1em;
       height: 1em; }
-    .section h3 span.icon svg, .panel h3 span.icon svg {
+    .section > h3 span.icon svg, .panel > h3 span.icon svg {
       width: 1em;
       height: 1em; }
   .section > div, .panel > div {
@@ -1498,7 +1498,7 @@ a:hover {
   -moz-box-shadow: inset 0 1px 4px #dddddd;
   -webkit-box-shadow: inset 0 1px 4px #dddddd;
   margin-bottom: 20px; }
-  .sidebar_section h3 {
+  .sidebar_section > h3 {
     background: #efefef;
     background: -webkit-gradient(linear, left top, left bottom, from(#efefef), to(#dfe1e2));
     background: -moz-linear-gradient(-90deg, #efefef, #dfe1e2);
@@ -1522,12 +1522,12 @@ a:hover {
     margin-bottom: 0.5em;
     color: #5e6469;
     padding: 5px 10px 3px 10px; }
-    .sidebar_section h3 span.icon svg path, .sidebar_section h3 span.icon svg polygon, .sidebar_section h3 span.icon svg rect, .sidebar_section h3 span.icon svg circle {
+    .sidebar_section > h3 span.icon svg path, .sidebar_section > h3 span.icon svg polygon, .sidebar_section > h3 span.icon svg rect, .sidebar_section > h3 span.icon svg circle {
       fill: #5e6469 !important; }
-    .sidebar_section h3 span.icon {
+    .sidebar_section > h3 span.icon {
       width: 1em;
       height: 1em; }
-    .sidebar_section h3 span.icon svg {
+    .sidebar_section > h3 span.icon svg {
       width: 1em;
       height: 1em; }
   .sidebar_section > div {
@@ -1535,6 +1535,9 @@ a:hover {
   .sidebar_section hr {
     border: none;
     border-bottom: 1px solid #E8E8E8; }
+
+.columns {
+  margin-bottom: 10px; }
 
 .scopes li .count {
   color: #8e979e;
@@ -1743,7 +1746,7 @@ table.dashboard {
     -moz-box-shadow: inset 0 1px 4px #dddddd;
     -webkit-box-shadow: inset 0 1px 4px #dddddd;
     margin-bottom: 20px; }
-    table.dashboard .dashboard_section h3 {
+    table.dashboard .dashboard_section > h3 {
       background: #efefef;
       background: -webkit-gradient(linear, left top, left bottom, from(#efefef), to(#dfe1e2));
       background: -moz-linear-gradient(-90deg, #efefef, #dfe1e2);
@@ -1767,12 +1770,12 @@ table.dashboard {
       margin-bottom: 0.5em;
       color: #5e6469;
       padding: 5px 10px 3px 10px; }
-      table.dashboard .dashboard_section h3 span.icon svg path, table.dashboard .dashboard_section h3 span.icon svg polygon, table.dashboard .dashboard_section h3 span.icon svg rect, table.dashboard .dashboard_section h3 span.icon svg circle {
+      table.dashboard .dashboard_section > h3 span.icon svg path, table.dashboard .dashboard_section > h3 span.icon svg polygon, table.dashboard .dashboard_section > h3 span.icon svg rect, table.dashboard .dashboard_section > h3 span.icon svg circle {
         fill: #5e6469 !important; }
-      table.dashboard .dashboard_section h3 span.icon {
+      table.dashboard .dashboard_section > h3 span.icon {
         width: 1em;
         height: 1em; }
-      table.dashboard .dashboard_section h3 span.icon svg {
+      table.dashboard .dashboard_section > h3 span.icon svg {
         width: 1em;
         height: 1em; }
     table.dashboard .dashboard_section > div {

--- a/test/fixtures/admin_users.yml
+++ b/test/fixtures/admin_users.yml
@@ -4,8 +4,9 @@
 # model remove the '{}' from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
+#one: {}
 # column: value
 #
-two: {}
+#two: {}
 #  column: value
+

--- a/test/fixtures/user_addresses.yml
+++ b/test/fixtures/user_addresses.yml
@@ -1,0 +1,12 @@
+# Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
+
+# This model initially had no columns defined.  If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+#  column: value
+

--- a/test/unit/product_test.rb
+++ b/test/unit/product_test.rb
@@ -16,5 +16,17 @@ class ProductTest < ActiveSupport::TestCase
   def test_should_be_valid
     assert new_product.valid?
   end
+
+  def test_require_title
+    assert new_product(:title => '').errors[:title]
+  end
+
+  def test_require_price
+    assert new_product(:price => '').errors[:price]
+  end
+
+  def test_require_image
+    assert new_product(:image_file_name => '').errors[:image_file_name]
+  end
 end
 

--- a/test/unit/product_test.rb
+++ b/test/unit/product_test.rb
@@ -1,7 +1,20 @@
 require 'test_helper'
 
 class ProductTest < ActiveSupport::TestCase
+  def new_product(attrs = {})
+    attrs[:title]           ||= 'FooBar Product'
+    attrs[:price]           ||= 123.45
+    attrs[:image_file_name] ||= 'foobar.jpeg'
+    product = Product.new(attrs)
+    product
+  end
+
+  def setup
+    Product.delete_all
+  end
+
   def test_should_be_valid
-    assert Product.new.valid?
+    assert new_product.valid?
   end
 end
+

--- a/test/unit/user_address_test.rb
+++ b/test/unit/user_address_test.rb
@@ -12,13 +12,13 @@ class UserAddressTest < ActiveSupport::TestCase
   end
 
   def new_user_address(attrs = {})
-    attrs[:user_id]               ||= new_user.id
     attrs[:fullname]              ||= 'Martin McFly'
     attrs[:address_line1]         ||= '9303 Lion Drive'
     attrs[:city]                  ||= 'Hill Valley'
     attrs[:state]                 ||= 'California'
     attrs[:zipcode]               ||= '95420'
     attrs[:country]               ||= 'US'
+    attrs[:user_id] = attrs.has_key?(:user_id) ? attrs[:user_id] : new_user.id
     user_address = UserAddress.new(attrs)
     user_address.valid?
     user_address
@@ -31,6 +31,42 @@ class UserAddressTest < ActiveSupport::TestCase
 
   def test_valid
     assert new_user_address.valid?
+  end
+
+  def test_require_user
+    address = new_user_address(:user_id => nil)
+    assert address.user.nil?, "user should be nil"
+    assert !address.errors[:user_id].empty?, "should contain user_id error"
+  end
+
+  def test_require_fullname
+    address = new_user_address(:fullname => '')
+    assert !address.errors[:fullname].empty?
+  end
+
+  def test_require_address_line1
+    address = new_user_address(:address_line1 => '')
+    assert !address.errors[:address_line1].empty?
+  end
+
+  def test_require_city
+    address = new_user_address(:city => '')
+    assert !address.errors[:city].empty?
+  end
+
+  def test_require_state
+    address = new_user_address(:state => '')
+    assert !address.errors[:state].empty?
+  end
+
+  def test_require_zipcode
+    address = new_user_address(:zipcode => '')
+    assert !address.errors[:zipcode].empty?
+  end
+
+  def test_require_country
+    address = new_user_address(:country => '')
+    assert !address.errors[:country].empty?
   end
 end
 

--- a/test/unit/user_address_test.rb
+++ b/test/unit/user_address_test.rb
@@ -1,9 +1,36 @@
 require 'test_helper'
 
 class UserAddressTest < ActiveSupport::TestCase
-  # Replace this with your real tests.
-  test "the truth" do
-    assert true
+  def new_user(attrs = {})
+    attrs[:username]              ||= 'martin.mcFly'
+    attrs[:email]                 ||= 'martin@mcf.ly'
+    attrs[:password]              ||= 'abc123'
+    attrs[:password_confirmation] ||= attrs[:password]
+    user = User.new(attrs)
+    user.save!
+    user
+  end
+
+  def new_user_address(attrs = {})
+    attrs[:user_id]               ||= new_user.id
+    attrs[:fullname]              ||= 'Martin McFly'
+    attrs[:address_line1]         ||= '9303 Lion Drive'
+    attrs[:city]                  ||= 'Hill Valley'
+    attrs[:state]                 ||= 'California'
+    attrs[:zipcode]               ||= '95420'
+    attrs[:country]               ||= 'US'
+    user_address = UserAddress.new(attrs)
+    user_address.valid?
+    user_address
+  end
+
+  def setup
+    UserAddress.delete_all
+    User.delete_all
+  end
+
+  def test_valid
+    assert new_user_address.valid?
   end
 end
 

--- a/test/unit/user_address_test.rb
+++ b/test/unit/user_address_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class UserAddressTest < ActiveSupport::TestCase
+  # Replace this with your real tests.
+  test "the truth" do
+    assert true
+  end
+end
+


### PR DESCRIPTION
I want to use this draft to write some docs explaining belongs_to awesome feature!

Any feedback will be appreciated.

Notes:

1) admin/users.rb 
It was registered as "Customer":
ActiveAdmin.register User, :as => "Customer" do
...

but it definitelly breaks belongs_to, so I needed to remove customer declaration.

2.1) admin/user_addresses.rb
I customized the generated form to render user_id input as hidden field instead of select, because user is "already choosen" when we are using new_admin_user_user_address_path(user.id) - It doens't make sense allow to change it inside the form.

2.2) I needed update Gemfile to use ActiveAdmin head - without it, user_address form was not resolving params, used to set user_id hidden value (params[:user_id]).

3) I was able to fix and run unit tests, but I could not run functional tests (mock calls not available). Is Rspec deps necessary to be declared in Gemfile?

Thanks!
