### PR TITLE
Refresh application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,6 @@
 # Ignore bundler config.
 /.bundle
 
-# Ignore the default SQLite database.
-/db/*.sqlite3
-/db/*.sqlite3-journal
-
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,0 @@
-ruby:
-  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 ---
 
+require: rubocop-rspec
+
 AllCops:
   DisabledByDefault: true
 
@@ -12,3 +14,6 @@ AllCops:
 
 Metrics:
   Enabled: false
+
+FactoryBot/AttributeDefinedStatically:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,14 @@
-Metrics/BlockLength:
-  Max: 35
+---
 
-Metrics/LineLength:
-  Max: 100
+AllCops:
+  DisabledByDefault: true
 
-Style/FrozenStringLiteralComment:
+  TargetRubyVersion: 2.5
+  TargetRailsVersion: 5.2
+
+  DisplayCopNames: true
+
+  StyleGuideCopsOnly: false
+
+Metrics:
   Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
 rvm:
   - 2.5.3
+before_script:
+  - RAILS_ENV=test bin/rails db:create db:migrate
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
-  - 2.3
+  - 2.5.3
 cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,9 @@ group :development do
   gem 'mechanize','2.7.3'
 end
 
+gem 'pg', '~> 0.20'
+
 group :production do
-  gem 'pg', '~> 0.20'
   gem 'unicorn'
 
   # Enable gzip compression on heroku, but don't compress images.
@@ -42,7 +43,6 @@ group :production do
 end
 
 group :development, :test do
-  gem 'sqlite3'
   gem 'factory_bot_rails'
   gem 'rspec-rails', '~> 3.4'
   gem 'rubocop', '0.60.0'

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :development, :test do
   gem 'sqlite3'
   gem 'factory_bot_rails'
   gem 'rspec-rails', '~> 3.4'
+  gem 'rubocop', '0.60.0'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ end
 
 group :development, :test do
   gem 'sqlite3'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'rspec-rails', '~> 3.4'
   gem 'spork', '~> 1.0rc'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'rspec-rails', '~> 3.4'
   gem 'rubocop', '0.60.0'
+  gem 'rubocop-rspec', '~> 1.30'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,6 @@ group :development, :test do
 end
 
 group :test do
-  gem 'shoulda', github: 'thoughtbot/shoulda'
   gem "shoulda-matchers"
   gem "webmock", "~> 1.11.0"
   gem "webrat"

--- a/Gemfile
+++ b/Gemfile
@@ -35,9 +35,6 @@ group :production do
   # Enable gzip compression on heroku, but don't compress images.
   gem 'heroku-deflater'
 
-  # Heroku injects it if it's not in there already
-  gem 'rails_12factor'
-
   gem 'rack-throttle'
   gem 'rack-cache'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ end
 group :test do
   gem "shoulda-matchers"
   gem "webmock", "~> 1.11.0"
-  gem "webrat"
   gem 'simplecov', :require => false
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ group :development, :test do
   gem 'sqlite3'
   gem 'factory_bot_rails'
   gem 'rspec-rails', '~> 3.4'
-  gem 'spork', '~> 1.0rc'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,4 +331,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.16.3
+   1.17.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: git://github.com/thoughtbot/shoulda.git
-  revision: 0e1d08d1df610e221fa757a6b2d9551035cc8184
-  specs:
-    shoulda (3.5.0)
-      shoulda-context (~> 1.0, >= 1.0.1)
-      shoulda-matchers (~> 3.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -256,7 +248,6 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    shoulda-context (1.2.2)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     simplecov (0.16.1)
@@ -327,7 +318,6 @@ DEPENDENCIES
   rails (~> 5.2.0)
   rails_12factor
   rspec-rails (~> 3.4)
-  shoulda!
   shoulda-matchers
   simplecov
   spork (~> 1.0rc)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,6 +257,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
+    rubocop-rspec (1.30.0)
+      rubocop (>= 0.58.0)
     ruby-progressbar (1.10.0)
     safe_yaml (1.0.4)
     sass (3.5.7)
@@ -335,6 +337,7 @@ DEPENDENCIES
   rails_12factor
   rspec-rails (~> 3.4)
   rubocop (= 0.60.0)
+  rubocop-rspec (~> 1.30)
   shoulda-matchers
   simplecov
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,10 +308,6 @@ GEM
     webmock (1.11.0)
       addressable (>= 2.2.7)
       crack (>= 0.3.2)
-    webrat (0.7.3)
-      nokogiri (>= 1.2.0)
-      rack (>= 1.0)
-      rack-test (>= 0.5.3)
     webrobots (0.1.2)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
@@ -346,7 +342,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   webmock (~> 1.11.0)
-  webrat
 
 RUBY VERSION
    ruby 2.5.3p105

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     thor (0.20.0)
     thread_safe (0.3.6)
     turbolinks (5.1.1)
@@ -337,7 +336,6 @@ DEPENDENCIES
   shoulda-matchers
   simplecov
   spring
-  sqlite3
   turbolinks
   uglifier (>= 1.3.0)
   unicorn

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,10 +103,10 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.1)
     execjs (2.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.11.1)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.11.1)
+      factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
     faker (1.8.7)
       i18n (>= 0.7)
@@ -316,7 +316,7 @@ DEPENDENCIES
   airbrake
   country_select
   devise
-  factory_girl_rails
+  factory_bot_rails
   faker
   heroku-deflater
   mechanize (= 2.7.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,7 @@ DEPENDENCIES
   webrat
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.5.3p105
 
 BUNDLED WITH
    1.17.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,11 +207,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.2.1)
       actionpack (= 5.2.1)
       activesupport (= 5.2.1)
@@ -329,7 +324,6 @@ DEPENDENCIES
   rack-cache
   rack-throttle
   rails (~> 5.2.0)
-  rails_12factor
   rspec-rails (~> 3.4)
   rubocop (= 0.60.0)
   rubocop-rspec (~> 1.30)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     airbrake (7.3.4)
       airbrake-ruby (~> 2.10)
-    airbrake-ruby (2.10.0)
+    airbrake-ruby (2.12.0)
     arbre (1.1.1)
       activesupport (>= 3.0.0)
     arel (9.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
     arbre (1.1.1)
       activesupport (>= 3.0.0)
     arel (9.0.0)
+    ast (2.4.0)
     bcrypt (3.1.12)
     builder (3.2.3)
     coffee-rails (4.2.2)
@@ -123,6 +124,7 @@ GEM
       has_scope (~> 0.6)
       railties (>= 4.2, < 5.3)
       responders
+    jaro_winkler (1.5.1)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -173,7 +175,11 @@ GEM
       mini_portile2 (~> 2.3.0)
     ntlm-http (0.1.1)
     orm_adapter (0.5.0)
+    parallel (1.12.1)
+    parser (2.5.3.0)
+      ast (~> 2.4.0)
     pg (0.21.0)
+    powerpack (0.1.2)
     public_suffix (3.0.2)
     rack (2.0.5)
     rack-cache (1.8.0)
@@ -212,6 +218,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
+    rainbow (3.0.0)
     raindrops (0.19.0)
     rake (12.3.1)
     ransack (2.0.0)
@@ -242,6 +249,15 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
+    rubocop (0.60.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.4.0)
+    ruby-progressbar (1.10.0)
     safe_yaml (1.0.4)
     sass (3.5.7)
       sass-listen (~> 4.0.0)
@@ -280,6 +296,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
+    unicode-display_width (1.4.0)
     unicode_utils (1.4.0)
     unicorn (5.4.0)
       kgio (~> 2.6)
@@ -317,6 +334,7 @@ DEPENDENCIES
   rails (~> 5.2.0)
   rails_12factor
   rspec-rails (~> 3.4)
+  rubocop (= 0.60.0)
   shoulda-matchers
   simplecov
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,7 +258,6 @@ GEM
     sixarm_ruby_unaccent (1.2.0)
     sort_alphabetical (1.1.0)
       unicode_utils (>= 1.2.2)
-    spork (1.0.0rc4)
     spring (2.0.2)
       activesupport (>= 4.2)
     sprockets (3.7.2)
@@ -320,7 +319,6 @@ DEPENDENCIES
   rspec-rails (~> 3.4)
   shoulda-matchers
   simplecov
-  spork (~> 1.0rc)
   spring
   sqlite3
   turbolinks

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,7 +19,3 @@ development:
 test:
   <<: *default
   database: db/test.sqlite3
-
-production:
-  <<: *default
-  database: db/production.sqlite3

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,21 +1,17 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
   pool: 5
   timeout: 5000
+  username: <%= ENV.fetch("DATABASE_USERNAME") { "postgres" } %>
+  password: <%= ENV.fetch("DATABASE_PASSWORD") { "" } %>
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: demo_aa_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: demo_aa_test

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,5 +1,6 @@
 default: &default
   adapter: postgresql
+  host: localhost
   pool: 5
   timeout: 5000
   username: <%= ENV.fetch("DATABASE_USERNAME") { "postgres" } %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,12 @@ Rails.application.configure do
   config.action_dispatch.rack_cache = true
 
   # Enable Rails's static asset server (Apache or nginx not in use).
-  config.public_file_server.enabled = true
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -19,3 +19,7 @@ end
 # don't send sensitive information to Airbrake in your body (such as passwords).
 # https://github.com/airbrake/airbrake#requestbodyfilter
 Airbrake.add_filter(Airbrake::Rack::RequestBodyFilter.new)
+
+Airbrake.add_filter do |notice|
+  notice.ignore! if notice.stash[:exception].is_a?(ActiveRecord::RecordNotFound)
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20120222083938) do
+ActiveRecord::Schema.define(version: 2012_02_22_083938) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string "namespace"
     t.text "body"
     t.string "resource_type"
-    t.integer "resource_id"
+    t.bigint "resource_id"
     t.string "author_type"
-    t.integer "author_id"
+    t.bigint "author_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"

--- a/spec/factories/line_items.rb
+++ b/spec/factories/line_items.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :line_item do
     order_id 1
     product_id 1

--- a/spec/factories/line_items.rb
+++ b/spec/factories/line_items.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :line_item do
-    order_id 1
-    product_id 1
-    price "9.99"
+    order_id { 1 }
+    product_id { 1 }
+    price { "9.99" }
   end
 
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :order do
-    user_id 1
-    checked_out_at "2014-12-21 15:08:25"
-    total_price "9.99"
+    user_id { 1 }
+    checked_out_at { "2014-12-21 15:08:25" }
+    total_price { "9.99" }
   end
 
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :order do
     user_id 1
     checked_out_at "2014-12-21 15:08:25"

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :product do
     title "MyString"
     description "MyText"

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
   factory :product do
-    title "MyString"
-    description "MyText"
-    author "MyString"
-    price "9.99"
-    featured false
-    available_on "2014-12-21"
-    image_file_name "MyString"
+    title { "MyString" }
+    description { "MyText" }
+    author { "MyString" }
+    price { "9.99" }
+    featured { false }
+    available_on { "2014-12-21" }
+    image_file_name { "MyString" }
   end
 
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :user do
-    username "MyString"
-    email "MyString"
-    password_hash "MyString"
-    password_salt "MyString"
+    username { "MyString" }
+    email { "MyString" }
+    password_hash { "MyString" }
+    password_salt { "MyString" }
   end
 
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     username "MyString"
     email "MyString"


### PR DESCRIPTION
I want to try out here the 1-4-stable branch in activeadmin before releasing it, but I'm refreshing this app a bit first.

* Removes a bunch of unused gems.
* Removes hound in favor of plain rubocop.
* Removes warnings about factory girl by migrating to factory bot.
* Removes warnings about sqlite stuff by using postgreSQL in all environments.
* Bumps to ruby 2.5.3.
* Bump airbrake-ruby and ignore 404 errors from its reports. 