### PR TITLE
Move airbrake to production block

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem "devise"
 
 gem "faker"
 gem 'newrelic_rpm', '~> 5.5'
-gem 'airbrake'
 
 gem 'country_select'
 
@@ -30,6 +29,7 @@ end
 gem 'pg', '~> 1.1'
 
 group :production do
+  gem 'airbrake'
   gem 'unicorn'
 
   # Enable gzip compression on heroku, but don't compress images.

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,3 +1,5 @@
+return unless Rails.env.production?
+
 # Configuration details:
 # https://github.com/airbrake/airbrake-ruby#configuration
 Airbrake.configure do |c|


### PR DESCRIPTION
Otherwise an error is triggered when shutting down the server in development because airbrake credentials are not configured.