### PR TITLE
Convert base JS file to plain JS

### DIFF
--- a/app/assets/javascripts/active_admin.js
+++ b/app/assets/javascripts/active_admin.js
@@ -1,0 +1,1 @@
+//= require active_admin/base

--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -1,1 +1,0 @@
-#= require active_admin/base


### PR DESCRIPTION
The autodeploy triggered after merging #80 failed. The good news is that autodeploys are working :)

This PR should fix it by converting the base JS file to plain JS since ActiveAdmin 2.0 no longer depends on coffeescript.