### PR TITLE
Lock PostgreSQL version in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
+addons:
+  - postgresql: 9.6
 language: ruby
 rvm:
   - 2.5.3
 before_script:
   - RAILS_ENV=test bin/rails db:create db:migrate
 cache: bundler
+services:
+  - postgresql


### PR DESCRIPTION
It seems like TravisCI has changed its default version, and that the new version has a different default configuration, so CI is failing.

Let's lock the version, so that this kind of infrastructure changes never break our CI.