### PR TITLE
Run Rubocop in CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ AllCops:
   TargetRubyVersion: 2.6
   TargetRailsVersion: 5.2
 
+  Exclude:
+    - vendor/bundle/**/*
+
   DisplayCopNames: true
 
   StyleGuideCopsOnly: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 ---
 
-require: rubocop-rspec
+require:
+  - rubocop-rspec
+  - rubocop-rails
 
 AllCops:
   DisabledByDefault: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ rvm:
   - 2.6.5
 before_script:
   - RAILS_ENV=test bin/rails db:create db:migrate
+script:
+  - bundle exec rubocop
+  - bundle exec rake
 cache: bundler
 services:
   - postgresql

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'rspec-rails', '~> 3.8'
   gem 'rubocop', '0.77.0'
+  gem 'rubocop-rails', '~> 2.4'
   gem 'rubocop-rspec', '~> 1.30'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,6 +266,9 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-rails (2.4.0)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
     rubocop-rspec (1.37.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
@@ -345,6 +348,7 @@ DEPENDENCIES
   rails (~> 6.0.0)
   rspec-rails (~> 3.8)
   rubocop (= 0.77.0)
+  rubocop-rails (~> 2.4)
   rubocop-rspec (~> 1.30)
   shoulda-matchers
   simplecov


### PR DESCRIPTION
We were depending on `rubocop` but were not actually running it in CI.

This PR adds a CI step to run `rubocop` and also includes `rubocop-rails` in our `Gemfile` since it was extracted out of rubocop core a few releases ago, but we didn't add it.