### PR TITLE
open side bar links in a new tab by default

### DIFF
--- a/app/views/admin/_sidebar_links.html.erb
+++ b/app/views/admin/_sidebar_links.html.erb
@@ -1,5 +1,5 @@
-This is the demo app for <%= link_to "Active Admin", "https://activeadmin.info" %>.
+This is the demo app for <%= link_to "Active Admin", "https://activeadmin.info", target: "_blank" %>.
 Don't hesitate to check out the
-<%= link_to("source code for this page", "https://github.com/activeadmin/demo.activeadmin.info/blob/master/app/admin/#{model}.rb") %>,
-the <%= link_to("Documentation", "https://activeadmin.info/docs/documentation.html") %>
-and the <%= link_to("Github Repo", "https://github.com/activeadmin/activeadmin") %>.
+<%= link_to("source code for this page", "https://github.com/activeadmin/demo.activeadmin.info/blob/master/app/admin/#{model}.rb", target: "_blank") %>,
+the <%= link_to("Documentation", "https://activeadmin.info/docs/documentation.html", target: "_blank") %>
+and the <%= link_to("Github Repo", "https://github.com/activeadmin/activeadmin", target: "_blank") %>.


### PR DESCRIPTION
open the sidebar links in a new tab to make it easier to view the documentation along with the page.