### PR TITLE
Update Airbrake config with blocklist_keys

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -14,7 +14,7 @@ Airbrake.configure do |c|
 
   c.ignore_environments = %w(test development)
 
-  c.blacklist_keys = [/password/i, /authorization/i]
+  c.blocklist_keys = [/password/i, /authorization/i]
 end
 
 # A filter that collects request body information. Enable it if you are sure you


### PR DESCRIPTION
This config was renamed to `blocklist_keys` but the changelog for the v11 release didn't contain the breaking change. This should resolve the deployment issue.