### PR TITLE
Add active storage to support creating new products with images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,3 +54,4 @@ group :test do
   gem 'simplecov', :require => false
 end
 
+gem "image_processing", "~> 1.12"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,9 @@ GEM
     i18n (1.8.8)
       concurrent-ruby (~> 1.0)
     i18n_data (0.8.0)
+    image_processing (1.12.1)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     inherited_resources (1.12.0)
       actionpack (>= 5.2, < 6.2)
       has_scope (~> 0.6)
@@ -169,6 +172,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
     mimemagic (0.3.5)
+    mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
@@ -271,6 +275,8 @@ GEM
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby2_keywords (0.0.2)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -341,6 +347,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   heroku-deflater
+  image_processing (~> 1.12)
   mechanize (= 2.7.7)
   newrelic_rpm (~> 6.0)
   pg (~> 1.1)

--- a/app/admin/products.rb
+++ b/app/admin/products.rb
@@ -1,6 +1,6 @@
 ActiveAdmin.register Product do
   menu :priority => 2
-  permit_params :title, :description,:author,:price, :featured, :available_on,:image_file_name
+  permit_params :title, :description,:author,:price, :featured, :available_on, :image_file_name, :image
 
   scope :all, :default => true
   scope :available do |products|
@@ -13,11 +13,28 @@ ActiveAdmin.register Product do
     products.where(:featured => true)
   end
 
+  form :html => { :multipart => true } do |f|
+    f.inputs do
+      f.semantic_errors
+
+      f.input :title
+      f.input :description
+      f.input :author
+      f.input :price
+      f.input :available_on
+      f.input :image_file_name
+      f.input :image, as: :file
+
+      f.actions
+    end
+  end
+
   index :as => :grid do |product|
     div do
       resource_selection_cell product
       a :href => admin_product_path(product) do
-        image_tag("products/" + product.image_file_name)
+        image_url = product.image.attached? ? product.image.variant(resize_to_limit: [115, 115]) : "products/" + product.image_file_name
+        image_tag(image_url)
       end
     end
     a truncate(product.title), :href => admin_product_path(product)

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,5 @@
 class Product < ActiveRecord::Base
+  has_one_attached :image
 
   # Named Scopes
   scope :available, lambda{ where("available_on < ?", Date.today) }

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,1 @@
+Rails.application.config.active_storage.service = :local

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,3 @@
+local:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>

--- a/db/migrate/20210204190042_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210204190042_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2012_02_22_083938) do
+ActiveRecord::Schema.define(version: 2021_02_04_190042) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,27 @@ ActiveRecord::Schema.define(version: 2012_02_22_083938) do
     t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
     t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
     t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id"
+  end
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
   create_table "admin_users", force: :cascade do |t|
@@ -103,4 +124,5 @@ ActiveRecord::Schema.define(version: 2012_02_22_083938) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
Currently the only way to create a new product is with a broken image. This currently fallsback to the public assets folder and since an image with the right name is not there it just shows a broken link. But this is deprecated and the app crashes on Rails 6.1 here.

This PR adds the ability to select images for new products to fix this issue.