### PR TITLE
Reload DB on deployments

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: bundle exec rails db:migrate
 web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb


### PR DESCRIPTION
I think DB migrations were not applied after #502.

I was expecting heroku to run the postdeploy script on regular builds too, but it seems like it's only run for review apps, and we need to configure it in the `Procfile` to be run on regular builds.

https://devcenter.heroku.com/articles/release-phase