### PR TITLE
Reload DB on deployments (bis)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:schema:load db:seed
 web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb

--- a/app.json
+++ b/app.json
@@ -1,9 +1,6 @@
 {
   "name": "demo.activeadmin.info",
   "description": "The demo application for Active Admin",
-  "scripts": {
-    "postdeploy": "bundle exec rails db:schema:load db:seed"
-  },
   "env": {
     "AIRBRAKE_API_KEY": {
       "required": true


### PR DESCRIPTION
I was expecting heroku to run the postdeploy script on regular builds too, but it seems like it's only run for review apps, and we need to configure it in the `Procfile` to be run on regular builds.

https://devcenter.heroku.com/articles/release-phase

This is a followup to #503. Apparently the postdeploy script only runs the first time after a PR is created, not on subsequent pushes. So I want to see what happens here, since I don't remember how #503 started.