### PR TITLE
Configure `rack-throttle` again

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,4 +90,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.middleware.use Rack::Throttle::Daily,    :max => 1000  # requests
+  config.middleware.use Rack::Throttle::Minute,   :max => 60    # requests
 end


### PR DESCRIPTION
We used to have this configured, but I removed it accidentally.