### PR TITLE
Don't require `SECRET_KEY_BASE` for review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -66,9 +66,6 @@
         "RAILS_SERVE_STATIC_FILES": {
           "required": true,
           "value": "enabled"
-        },
-        "SECRET_KEY_BASE": {
-          "required": true
         }
       }
     }


### PR DESCRIPTION
Not sure why now, but I'm getting an error when creating review apps
that reads:

> Could not create review app. Invalid app.json. Config var "SECRET_KEY_BASE" is required.