### PR TITLE
Fix deprecation warning with fixture paths

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,7 +19,9 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_paths = [
+    Rails.root.join("spec/fixtures")
+  ]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
Rails 7.1 has deprecated the singular fixture_path in favour of an array

Ref: https://github.com/activeadmin/demo.activeadmin.info/actions/runs/7375269680/job/20066620916#step:8:9