### PR TITLE
Add YAML and GHA lint workflows

### DIFF
--- a/.github/workflows/github-actions-lint.yml
+++ b/.github/workflows/github-actions-lint.yml
@@ -1,0 +1,24 @@
+name: GitHub Actions Lint
+
+on:
+  pull_request:
+
+jobs:
+  github_actions_lint:
+    name: Run actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@v41
+        id: changed-files
+        with:
+          files: |
+            .github/workflows/*.yaml
+            .github/workflows/*.yml
+      - uses: reviewdog/action-actionlint@v1
+        if: steps.changed-files.outputs.any_changed == 'true'
+        with:
+          fail_on_error: true
+          filter_mode: nofilter # added (default), diff_context, file, nofilter
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-check

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,0 +1,24 @@
+name: YAML Lint
+
+on:
+  pull_request:
+
+jobs:
+  yaml_lint:
+    name: Run yamllint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@v41
+        id: changed-files
+        with:
+          files: |
+            **.yaml
+            **.yml
+      - uses: reviewdog/action-yamllint@v1
+        if: steps.changed-files.outputs.any_changed == 'true'
+        with:
+          fail_on_error: true
+          filter_mode: nofilter # added (default), diff_context, file, nofilter
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-check

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,17 @@
+# https://yamllint.readthedocs.io/en/stable/configuration.html
+extends: default
+ignore: |
+  node_modules/
+  tmp/
+  vendor/
+rules: # https://yamllint.readthedocs.io/en/stable/rules.html
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  line-length: disable
+  truthy:
+    allowed-values:
+      - "true"
+      - "false"
+      - "on"
+      - "off"


### PR DESCRIPTION
This adds YAML and GHA lint workflows to CI. Since the Required Workflows feature is deprecated, we'll start by inlining these in the repo as we are planning to do the same for other repos too. This will also help us test the Codecov change (previous PR) on merge.