### PR TITLE
Improve setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ https://activeadmin-demo.onrender.com
 - Clone this repository
 - Install Ruby 3 with [rbenv](https://github.com/rbenv/rbenv)
 - Install Node 20 with [nodenv](https://github.com/nodenv/nodenv)
+- `corepack enable`
 - `bundle install`
+- `yarn install`
 - `bin/rails db:seed`
 - `bin/dev`
 

--- a/package.json
+++ b/package.json
@@ -7,5 +7,6 @@
   },
   "scripts": {
     "build:css": "tailwindcss -i ./app/assets/stylesheets/active_admin.css -o ./app/assets/builds/active_admin.css --minify -c tailwind-active_admin.config.js"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
I found that it was missing that you need `yarn` installed, and `yarn install` run in order to get started.

To make `yarn` available, I added a `packageManager` field with latest yarn 1.x version to `package.json` and included `corepack enable` so that this field is respected and nodejs automatically installs yarn when first run.

I also added `yarn install` to setup instructions.