### PR TITLE
Bump @activeadmin/activeadmin from 4.0.0-beta9 to 4.0.0-beta15 and @rails/ujs from 7.1.2 to 7.1.400

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "sprockets-rails"
 gem "cssbundling-rails"
 gem "importmap-rails"
 
-gem "activeadmin", "4.0.0.beta14" # github: "activeadmin/activeadmin", branch: "master"
+gem "activeadmin", "4.0.0.beta15" # github: "activeadmin/activeadmin", branch: "master"
 gem "devise"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activeadmin (4.0.0.beta14)
+    activeadmin (4.0.0.beta15)
       arbre (~> 2.0)
       csv
       formtastic (>= 3.1)
@@ -83,8 +83,8 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    arbre (2.0.2)
-      activesupport (>= 3.0.0)
+    arbre (2.1.0)
+      activesupport (>= 7.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark (0.4.0)
@@ -104,7 +104,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
-    csv (3.3.0)
+    csv (3.3.2)
     date (3.4.1)
     debug (1.10.0)
       irb (~> 1.10)
@@ -293,7 +293,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activeadmin (= 4.0.0.beta14)
+  activeadmin (= 4.0.0.beta15)
   capybara
   cssbundling-rails
   debug

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "app",
   "private": "true",
   "dependencies": {
-    "@activeadmin/activeadmin": "4.0.0-beta9",
+    "@activeadmin/activeadmin": "4.0.0-beta15",
     "tailwindcss": "^3.4.10"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,12 @@
 # yarn lockfile v1
 
 
-"@activeadmin/activeadmin@4.0.0-beta9":
-  version "4.0.0-beta9"
-  resolved "https://registry.yarnpkg.com/@activeadmin/activeadmin/-/activeadmin-4.0.0-beta9.tgz#b0e77bbffd94a1c428f34cb32640cb61fb329964"
-  integrity sha512-nsUSI4M5Zrujyjw92yQv/cV2edj7E6+D1HNZG0zqz98miPOxzPBJDXwpvQkE/iYSIeqc99NlLobFHxYXuzeB7Q==
+"@activeadmin/activeadmin@4.0.0-beta15":
+  version "4.0.0-beta15"
+  resolved "https://registry.yarnpkg.com/@activeadmin/activeadmin/-/activeadmin-4.0.0-beta15.tgz#5cfa3274826234073f138ae3507ea8e990475f84"
+  integrity sha512-TRQtxZ7lg/0lrxpRzanQwAoQnkYTgjpYkhk/N9UZQHhEans9Ra35blw2tO87NEdpYhMdos/hoHOTumczganHqw==
   dependencies:
-    "@rails/ujs" "7.1.2"
+    "@rails/ujs" "7.1.400"
     flowbite "2.3.0"
 
 "@alloc/quick-lru@^5.2.0":
@@ -90,10 +90,10 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
-"@rails/ujs@7.1.2":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-7.1.2.tgz#ea903bcc0224e17156015d995b6f1b83e27d64b2"
-  integrity sha512-c5x02djEKEVVE4qfN4XgElJS4biM0xxtIVpcJ0ZHLK116U19rowTtmD0AJ/RCb3Xaewa4GPIWLlwgeC0dCQqzw==
+"@rails/ujs@7.1.400":
+  version "7.1.400"
+  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-7.1.400.tgz#b2a76bdccb5197b9e866954536106386c87cfab5"
+  integrity sha512-YwvXm3BR5tn+VCAKYGycLejMRVZE3Ionj5gFjEeGXCZnI0Rpi+7dKpmyu90kdUY7dRUFpHTdu9zZceEzFLl38w==
 
 ansi-regex@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
Hi @tagliala @javierjulio,

It seems like the problem is related to an outdated npm package that is incompatible with the `activeadmin` gem version `4.0.0.beta14`. 

https://github.com/activeadmin/demo.activeadmin.info/blob/4bc7216b9681e5671be6630df92d31360666db06/Gemfile#L13

**Problem Output**
<details open> 
<summary>Click to view the problem output</summary>

```
08:45:31 web.1  | started with pid 512839
08:45:31 css.1  | started with pid 512840
08:45:31 css.1  | yarn run v1.22.22
08:45:31 css.1  | $ tailwindcss -i ./app/assets/stylesheets/active_admin.css -o ./app/assets/builds/active_admin.css --minify -c tailwind-active_admin.config.js --watch
08:45:31 css.1  | 
08:45:31 css.1  | Rebuilding...
08:45:32 web.1  | DEBUGGER: Debugger can attach via UNIX domain socket (/run/user/xxxx/rdbg-xxxxxx)
08:45:32 web.1  | => Booting Puma
08:45:32 web.1  | => Rails 7.2.2.1 application starting in development 
08:45:32 web.1  | => Run `bin/rails server --help` for more startup options
08:45:32 css.1  | (node:512950) ExperimentalWarning: CommonJS module ~/demo.activeadmin.info/tailwind-active_admin.config.js is loading ES Module ~/demo.activeadmin.info/node_modules/@activeadmin/activeadmin/plugin.js using require().
08:45:32 css.1  | Support for loading ES Module in require() is an experimental feature and might change at any time
08:45:32 css.1  | (Use `node --trace-warnings ...` to show where the warning was created)
08:45:32 css.1  | file://~/demo.activeadmin.info/node_modules/@activeadmin/activeadmin/plugin.js:1
08:45:32 css.1  | const plugin = require('tailwindcss/plugin')
08:45:32 css.1  |                ^
08:45:32 css.1  | 
08:45:32 css.1  | ReferenceError: require is not defined
08:45:32 css.1  |     at file://~/demo.activeadmin.info/node_modules/@activeadmin/activeadmin/plugin.js:1:16
08:45:32 css.1  |     at ModuleJobSync.runSync (node:internal/modules/esm/module_job:367:35)
08:45:32 css.1  |     at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:325:47)
08:45:32 css.1  |     at loadESMFromCJS (node:internal/modules/cjs/loader:1396:24)
08:45:32 css.1  |     at Module._compile (node:internal/modules/cjs/loader:1529:5)
08:45:32 css.1  |     at Object..js (node:internal/modules/cjs/loader:1678:16)
08:45:32 css.1  |     at Module.load (node:internal/modules/cjs/loader:1315:32)
08:45:32 css.1  |     at Function._load (node:internal/modules/cjs/loader:1125:12)
08:45:32 css.1  |     at TracingChannel.traceSync (node:diagnostics_channel:322:14)
08:45:32 css.1  |     at wrapModuleLoad (node:internal/modules/cjs/loader:216:24)
08:45:32 css.1  | 
08:45:32 css.1  | Node.js v23.1.0
08:45:32 css.1  | error Command failed with exit code 1.
08:45:32 css.1  | info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
08:45:33 web.1  | Puma starting in single mode...
08:45:33 web.1  | * Puma version: 6.5.0 ("Sky's Version")
08:45:33 web.1  | * Ruby version: ruby 3.3.4 (2024-07-09 revision be1089c8ec) [x86_64-linux]
08:45:33 web.1  | *  Min threads: 3
08:45:33 web.1  | *  Max threads: 3
08:45:33 web.1  | *  Environment: development
08:45:33 web.1  | *          PID: 512839
08:45:33 web.1  | * Listening on http://127.0.0.1:5000
08:45:33 web.1  | * Listening on http://[::1]:5000
08:45:33 web.1  | Use Ctrl-C to stop
08:45:33 css.1  | exited with code 1
08:45:33 system | sending SIGTERM to all processes
```

</details>

So I tried changing the version of `@activeadmin/activeadmin` to the latest version (`4.0.0-beta9` => `4.0.0-beta15`), and it worked well.

Please let me know if you have any questions or require further changes.