### PR TITLE
Add a non-ActiveRecord demo resource

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,8 @@ gem "sprockets-rails"
 gem "cssbundling-rails", "1.4.2" # TODO: relax this dependency when rails/cssbundling-rails#169 will be fixed
 gem "importmap-rails"
 
-gem "activeadmin", "4.0.0.beta22" # github: "activeadmin/activeadmin", branch: "master"
+# Temporary pin for non-ActiveRecord resources: https://github.com/activeadmin/activeadmin/pull/9039
+gem "activeadmin", github: "activeadmin/activeadmin", ref: "e372fc404d788824c0974894418313849f577a1c"
 gem "devise"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/activeadmin/activeadmin.git
+  revision: e372fc404d788824c0974894418313849f577a1c
+  ref: e372fc404d788824c0974894418313849f577a1c
+  specs:
+    activeadmin (4.0.0.beta22)
+      arbre (~> 2.0)
+      csv
+      formtastic (>= 6.0)
+      formtastic_i18n (>= 0.7)
+      inherited_resources (~> 2.0)
+      kaminari (>= 1.2.1)
+      railties (>= 7.2)
+      ransack (>= 4.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -47,15 +62,6 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activeadmin (4.0.0.beta22)
-      arbre (~> 2.0)
-      csv
-      formtastic (>= 6.0)
-      formtastic_i18n (>= 0.7)
-      inherited_resources (~> 2.0)
-      kaminari (>= 1.2.1)
-      railties (>= 7.2)
-      ransack (>= 4.0)
     activejob (8.1.3.1)
       activesupport (= 8.1.3.1)
       globalid (>= 0.3.6)
@@ -309,7 +315,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activeadmin (= 4.0.0.beta22)
+  activeadmin!
   capybara
   cssbundling-rails (= 1.4.2)
   debug

--- a/README.md
+++ b/README.md
@@ -19,3 +19,22 @@ Open http://localhost:5000 and login using `admin@example.com` and `password`.
 ### Tests
 
 Run `bin/rails test:all`
+
+## Non-ActiveRecord Example
+
+Open **API Posts** in the admin navigation to browse a read-only resource without
+an ActiveRecord model. This example follows
+[activeadmin/activeadmin#9039](https://github.com/activeadmin/activeadmin/pull/9039).
+
+- `app/models/api_post.rb` simulates an API with seven in-memory records. It filters
+  by title (case-sensitive substring) and status before returning a page and its
+  total count. No external service, credentials, migration, or seed data is needed.
+- `app/admin/api_posts.rb` overrides `find_collection` and uses
+  `Kaminari.paginate_array` to adapt the response for ActiveAdmin's pagination.
+  The search object keeps the filter inputs populated; **Clear Filters** resets them.
+- Sorting, downloads, comments, and batch actions are disabled. The active-filter
+  chips are also disabled because they require a Ransack search object.
+
+The ActiveAdmin gem is temporarily pinned to PR #9039's commit
+`e372fc404d788824c0974894418313849f577a1c`, which includes the required non-ActiveRecord
+fixes. Replace this pin with a released version containing those fixes when available.

--- a/app/admin/api_posts.rb
+++ b/app/admin/api_posts.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register ApiPost do
+  menu label: "API Posts"
+  actions :index
+
+  config.batch_actions = false
+  config.comments = false
+  config.per_page = 5
+  # Active-filter chips require a Ransack search, unlike the filter form.
+  config.current_filters = false
+
+  filter :title_cont, as: :string, label: "Title contains"
+  filter :status_eq, as: :select, label: "Status", collection: %w[active inactive]
+
+  index title: "API Posts", download_links: false do
+    column :id, sortable: false
+    column :title, sortable: false
+    column :status, sortable: false
+  end
+
+  controller do
+    protected
+
+    # Bypass the ActiveRecord pipeline and adapt an already-paginated API response.
+    def find_collection(*)
+      query = params[:q] || {}
+      @search = ApiPost::Search.new(title_cont: query[:title_cont], status_eq: query[:status_eq])
+
+      result = ApiPost.fetch(
+        page: params.fetch(:page, 1),
+        per_page: active_admin_config.per_page,
+        title_cont: search.title_cont,
+        status_eq: search.status_eq
+      )
+
+      Kaminari.paginate_array(
+        result.records,
+        total_count: result.total_count,
+        limit: result.limit,
+        offset: result.offset
+      )
+    end
+
+    private
+
+    attr_reader :search
+  end
+end

--- a/app/models/api_post.rb
+++ b/app/models/api_post.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# In-memory API stand-in adapted from activeadmin/activeadmin#9039.
+# Returns a page and metadata without a database or external service.
+class ApiPost
+  extend ActiveModel::Naming
+
+  Record = Data.define(:id, :title, :status)
+  Search = Data.define(:title_cont, :status_eq)
+  Result = Data.define(:records, :total_count, :limit, :offset)
+
+  ALL_RECORDS = [
+    Record.new(id: 1, title: "Alpha", status: "active"),
+    Record.new(id: 2, title: "Beta", status: "inactive"),
+    Record.new(id: 3, title: "Gamma", status: "active"),
+    Record.new(id: 4, title: "Delta", status: "active"),
+    Record.new(id: 5, title: "Epsilon", status: "inactive"),
+    Record.new(id: 6, title: "Zeta", status: "active"),
+    Record.new(id: 7, title: "Eta", status: "active")
+  ].freeze
+
+  def self.fetch(page: 1, per_page: 5, title_cont: nil, status_eq: nil)
+    page = [page.to_i, 1].max
+    per_page = per_page.to_i
+
+    records = ALL_RECORDS
+    records = records.select { |record| record.title.include?(title_cont) } if title_cont.present?
+    records = records.select { |record| record.status == status_eq } if status_eq.present?
+
+    offset = (page - 1) * per_page
+    page_records = if offset < records.size
+      records[offset, per_page]
+    else
+      []
+    end
+
+    Result.new(
+      records: page_records,
+      total_count: records.size,
+      limit: per_page,
+      offset: offset
+    )
+  end
+end

--- a/test/controllers/api_posts_controller_test.rb
+++ b/test/controllers/api_posts_controller_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ApiPostsControllerTest < ActionDispatch::IntegrationTest
+  test "authentication is required" do
+    get admin_api_posts_path
+
+    assert_redirected_to new_admin_user_session_path
+  end
+
+  test "only HTML is supported" do
+    sign_in default_admin_user
+
+    %i[csv json xml].each do |format|
+      get admin_api_posts_path(format: format)
+
+      assert_response :unauthorized
+    end
+  end
+
+  test "only the index action is routed" do
+    routes = Rails.application.routes.routes.select do |route|
+      route.defaults[:controller] == "admin/api_posts"
+    end
+
+    assert_equal ["index"], routes.map { |route| route.defaults[:action] }
+    assert_equal ["GET"], routes.map(&:verb)
+  end
+end

--- a/test/models/api_post_test.rb
+++ b/test/models/api_post_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ApiPostTest < ActiveSupport::TestCase
+  test "fetch returns a page of records and the total count" do
+    first_page = ApiPost.fetch
+    second_page = ApiPost.fetch(page: 2)
+
+    assert_equal %w[Alpha Beta Gamma Delta Epsilon], first_page.records.map(&:title)
+    assert_equal 7, first_page.total_count
+    assert_equal 5, first_page.limit
+    assert_equal 0, first_page.offset
+    assert_equal %w[Zeta Eta], second_page.records.map(&:title)
+    assert_equal 7, second_page.total_count
+    assert_equal 5, second_page.offset
+  end
+
+  test "filters are combined before pagination" do
+    result = ApiPost.fetch(title_cont: "ta", status_eq: "active", per_page: 2, page: 2)
+
+    assert_equal ["Eta"], result.records.map(&:title)
+    assert_equal 3, result.total_count
+    assert_equal 2, result.limit
+    assert_equal 2, result.offset
+    assert_equal 7, ApiPost.fetch.total_count
+  end
+
+  test "blank filters are ignored" do
+    result = ApiPost.fetch(title_cont: "", status_eq: "")
+
+    assert_equal 7, result.total_count
+    assert_equal 5, result.records.size
+  end
+
+  test "empty results and out of range pages return no records" do
+    no_matches = ApiPost.fetch(title_cont: "Missing")
+
+    assert_empty no_matches.records
+    assert_equal 0, no_matches.total_count
+
+    [3, 10**20].each do |page|
+      out_of_range = ApiPost.fetch(page: page)
+
+      assert_empty out_of_range.records
+      assert_equal 7, out_of_range.total_count
+    end
+  end
+
+  test "invalid page numbers use the first page" do
+    [0, -1, "invalid"].each do |page|
+      assert_equal ApiPost.fetch, ApiPost.fetch(page: page)
+    end
+  end
+end

--- a/test/system/active_admin/api_posts_test.rb
+++ b/test/system/active_admin/api_posts_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class ApiPostsTest < ApplicationSystemTestCase
+  setup do
+    sign_in default_admin_user
+  end
+
+  test "browsing a read-only resource across pages" do
+    visit admin_root_path
+    click_on "API Posts"
+
+    assert_current_path admin_api_posts_path
+    assert_text "Alpha"
+    assert_text "Epsilon"
+    refute_text "Zeta"
+    assert_text "Showing 1-5 of 7"
+    assert_no_selector "#index_table_api_posts th a"
+    assert_no_selector "input[type='checkbox']"
+    assert_no_link "New Api Post"
+    assert_no_link "CSV"
+
+    click_on "2", exact: true
+
+    assert_text "Zeta"
+    assert_text "Eta"
+    refute_text "Alpha"
+    assert_text "Showing 6-7 of 7"
+  end
+
+  test "filtering by status from the second page and clearing filters" do
+    visit admin_api_posts_path(page: 2)
+    select "inactive", from: "Status"
+    click_on "Filter", exact: true
+
+    assert_text "Beta"
+    assert_text "Epsilon"
+    refute_text "Alpha"
+    refute_text "Zeta"
+    assert_text "Showing all 2"
+    assert_select "Status", selected: "inactive"
+    assert_no_link "2", exact: true
+
+    click_on "Clear Filters"
+
+    assert_text "Alpha"
+    assert_text "Showing 1-5 of 7"
+    assert_select "Status", selected: "Any"
+    assert_link "2", exact: true
+  end
+
+  test "filtering by title and status" do
+    visit admin_api_posts_path
+    fill_in "Title contains", with: "Bet"
+    select "inactive", from: "Status"
+    click_on "Filter", exact: true
+
+    assert_text "Beta"
+    refute_text "Alpha"
+    refute_text "Epsilon"
+    assert_text "Showing 1 of 1"
+    assert_field "Title contains", with: "Bet"
+    assert_select "Status", selected: "inactive"
+    assert_no_link "2", exact: true
+  end
+
+  test "filtering without matches and clearing the empty result" do
+    visit admin_api_posts_path
+    fill_in "Title contains", with: "Missing"
+    click_on "Filter", exact: true
+
+    assert_text "No Api Posts found"
+    assert_field "Title contains", with: "Missing"
+    assert_no_selector "#index_table_api_posts"
+
+    click_on "Clear Filters"
+
+    assert_field "Title contains", with: ""
+    assert_text "Alpha"
+    assert_text "Showing 1-5 of 7"
+  end
+end


### PR DESCRIPTION
**Summary**
Provide a minimal sample in response to [the request from Javier Julio](https://github.com/activeadmin/activeadmin/pull/9039#pullrequestreview-5123117693).

- Add a read-only API Posts resource backed by seven in-memory records, without an external API or database changes.
- Demonstrate title/status filtering, retained filter inputs, Clear Filters, and API-style pagination.
- Disable unsupported sorting, downloads, comments, batch actions, and Ransack-only active-filter chips.
- Add model, request, and browser coverage plus usage documentation.

**Dependency**
Temporarily pin ActiveAdmin to `e372fc404d788824c0974894418313849f577a1c` from activeadmin/activeadmin#9039. The released beta22 lacks the required fixes. Replace this pin once a release includes them; no monkey patches are added.

**Verification**
- Full Rails test suite: 28 tests passing on the latest main base.
- RuboCop lint-only checks using the installed default configuration: passing. The existing repository RuboCop runner lacks its dependency and configuration.
- Ruby syntax checks and `git diff --check`: passing.

**AI Disclosure**
This minimal implementation was produced by GPT-6 Astra and has not been reviewed or verified by a human. Automated checks do not replace human review; this PR is intentionally a draft.

Refs activeadmin/activeadmin#9039